### PR TITLE
Load external scripts protocol independent

### DIFF
--- a/tinymce/gca-popup.html
+++ b/tinymce/gca-popup.html
@@ -4,9 +4,9 @@
 	<meta charset="utf-8" />
 	<title>Genesis Shortcodes Advanced - Outermost Design</title>
 		
-	<script language="javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-	<script language="javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+	<script language="javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+	<script language="javascript" src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
+	<link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 	<link rel="stylesheet" href="css/gca-popup.css" />
 	
 	<script type="text/javascript">	


### PR DESCRIPTION
Removing the `http:` part of the URL for the external scripts makes loading these scripts work in both HTTP and HTTPS environments.
